### PR TITLE
tests: proper usage of ng-mocks

### DIFF
--- a/src/app/stories/stories.component.spec.ts
+++ b/src/app/stories/stories.component.spec.ts
@@ -1,11 +1,12 @@
 import { MockBuilder, MockRender } from 'ng-mocks';
 import { EMPTY } from 'rxjs';
+
 import { StoriesService } from '../services/stories/stories.service';
 
 import { StoriesComponent } from './stories.component';
 import { StoriesComponentModule } from './stories.module';
 
-fdescribe('StoriesComponent', () => {
+describe('StoriesComponent', () => {
   beforeEach(() => MockBuilder(StoriesComponent, StoriesComponentModule)
     .mock(StoriesService, {
       getTopStories$: () => EMPTY,

--- a/src/app/stories/stories.component.spec.ts
+++ b/src/app/stories/stories.component.spec.ts
@@ -1,25 +1,19 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
-
-import { StoriesComponent } from './stories.component';
 import { MockBuilder, MockRender } from 'ng-mocks';
+import { EMPTY } from 'rxjs';
 import { StoriesService } from '../services/stories/stories.service';
 
-describe('StoriesComponent', () => {
-  let component: StoriesComponent;
-  let fixture: ComponentFixture<StoriesComponent>;
+import { StoriesComponent } from './stories.component';
+import { StoriesComponentModule } from './stories.module';
 
-  // TODO: go back to pure angular tests using hand-configured Jasmine spies and the default Angular TestBed.
-
-  beforeEach(async(() => {
-    MockBuilder(StoriesComponent);
-
-    fixture = MockRender(StoriesComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  }));
+fdescribe('StoriesComponent', () => {
+  beforeEach(() => MockBuilder(StoriesComponent, StoriesComponentModule)
+    .mock(StoriesService, {
+      getTopStories$: () => EMPTY,
+    })
+  );
 
   it('should create', () => {
+    const component = MockRender(StoriesComponent).point.componentInstance;
     expect(component).toBeTruthy();
   });
 });


### PR DESCRIPTION
Hi,

you were almost close, the thing with `MockBuilder` is that it returns a promise which should be awaited (that's why we should either use `async / await` or simply return it in the `beforeEach`), and to mock a service you could use `.mock(StoriesService)` with a custom definition.